### PR TITLE
CMIP5 wrapper

### DIFF
--- a/.unibeautifyrc.yml
+++ b/.unibeautifyrc.yml
@@ -7,8 +7,7 @@ Markdown:
   wrap_line_length: 80
 Python:
   beautifiers:
-    - YAPF
-    - black
+    - ["Black"]
   indent_size: 2
   indent_char: " "
   indent_space: "space"

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -7,25 +7,37 @@ import pandas as pd
 import xarray as xr
 from tqdm import tqdm_notebook
 
-# TODO: adapt for every user
+# builds on export WORK, GROUP
 try:
     my_system = None
-    host = os.hostname()
+    host = os.environ['HOSTNAME']
+    user = os.environ['USER']
+    work = os.environ['WORK']
+    group = os.environ['GROUP']
     for node in ['mlogin', 'mistralpp']:
         if node in host:
             my_system = 'mistral'
+    if 'm' is host[0]:
+        my_system = 'mistral'
     if my_system is None:
         my_system = 'local'
 except:
     my_system = 'local'
 
 if my_system is 'mistral':
-    file_origin = '/work/mh0727/m300524/'
+    file_origin = work
     tmp = file_origin + 'tmp'
+    if not os.path.exists(tmp):
+        os.makedirs(tmp)
 elif my_system is 'local':
-    #    file_origin = '/Users/aaron.spring/mistral_work/'
-    file_origin = '~/'
-    tmp = my_dir = os.path.expanduser('~/tmp')
+    mistral_work = '/Users/aaron.spring/mistral_work/'
+    work = mistral_work + 'mh0727/m300524/'  # group + '/' + user + '/'
+    file_origin = work
+    cdo_mistral = True
+    if cdo_mistral:
+        tmp = os.path.expanduser('~/tmp')
+    else:
+        tmp = file_origin + 'tmp'
     if not os.path.exists(tmp):
         os.makedirs(tmp)
 
@@ -44,7 +56,7 @@ PM_path = file_origin + 'experiments/'
 GE_path = file_origin + 'experiments/GE/'
 
 # cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output'
-cmip5_folder = '/work/kd0956/CMIP5/data/cmip5/output1'
+cmip5_folder = mistral_work+'kd0956/CMIP5/data/cmip5/output1'
 my_GE_path = file_origin + '160701_Grand_Ensemble/'
 GE_post = my_GE_path + 'postprocessed/'
 PM_post = PM_path + 'postprocessed/'

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -49,6 +49,11 @@ my_GE_path = file_origin + '160701_Grand_Ensemble/'
 GE_post = my_GE_path + 'postprocessed/'
 PM_post = PM_path + 'postprocessed/'
 
+cmip5_centers = ['MPI-M', 'NCAR', 'CCCma', 'MIROC', 'IPSL', 'NOAA-GFDL', 'MRI']
+
+cmip5_models = ['MPI-ESM-LR', 'CCSM4', 'CamESM2',
+                'MIROC-ESM', 'IPSL-CM5A-LR', 'GFDL-ESM2M', 'MRI-ESM1']
+
 
 def _get_path_cmip(base_folder=cmip5_folder,
                    model='MPI-ESM-LR',
@@ -60,9 +65,13 @@ def _get_path_cmip(base_folder=cmip5_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    path_v = sorted(glob.glob('/'.join([base_folder, center, model, exp,
-                                        period, comp, comp[0].upper()+period, run_id, 'v????????'])))[-1]
-    return path_v + '/' + varname + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
+    try:
+        path_v = sorted(glob.glob('/'.join([base_folder, center, model, exp,
+                                            period, comp, comp[0].upper()+period, run_id, 'v????????'])))[-1]
+        return path_v + '/' + varname + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
+    except:
+        return '/'.join([base_folder, center, model, exp,
+                         period, comp, comp[0].upper()+period, run_id])
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -60,7 +60,9 @@ def _get_path_cmip(base_folder=cmip5_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    return '/'.join([base_folder, center, model, exp, period, comp, comp[0].upper()+period, run_id, sorted(glob.glob('v????????'))[-1], varname]) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
+    path_v = sorted(glob.glob('/'.join([base_folder, center, model, exp,
+                                        period, comp, comp[0].upper()+period, run_id, 'v????????'])))[-1]
+    return path_v + '/' + varname + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -63,7 +63,7 @@ PM_post = PM_path + 'postprocessed/'
 
 cmip5_centers = ['MPI-M', 'NCAR', 'CCCma', 'MIROC', 'IPSL', 'NOAA-GFDL', 'MRI']
 
-cmip5_models = ['MPI-ESM-LR', 'CCSM4', 'CamESM2',
+cmip5_models = ['MPI-ESM-LR', 'CCSM4', 'CanESM2',
                 'MIROC-ESM', 'IPSL-CM5A-LR', 'GFDL-ESM2M', 'MRI-ESM1']
 
 

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -43,7 +43,7 @@ sample_file_dir = file_origin + 'experiments/sample_files/'
 PM_path = file_origin + 'experiments/'
 GE_path = file_origin + 'experiments/GE/'
 
-cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output/'
+cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output'
 my_GE_path = file_origin + '160701_Grand_Ensemble/'
 GE_post = my_GE_path + 'postprocessed/'
 PM_post = PM_path + 'postprocessed/'

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -58,7 +58,7 @@ def _get_path_cmip(base_folder=cmip5_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    return '/'.join([base_folder, center, model, exp, period, comp, varname, run_id]) + '/' + '_'.join([varname, comp[0].upper(), period, model, exp, run_id, timestr]) + ending
+    return '/'.join([base_folder, center, model, exp, period, comp, varname, run_id]) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -43,7 +43,8 @@ sample_file_dir = file_origin + 'experiments/sample_files/'
 PM_path = file_origin + 'experiments/'
 GE_path = file_origin + 'experiments/GE/'
 
-cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output'
+# cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output'
+cmip5_folder = '/work/kd0956/CMIP5/data/cmip5/output1'
 my_GE_path = file_origin + '160701_Grand_Ensemble/'
 GE_post = my_GE_path + 'postprocessed/'
 PM_post = PM_path + 'postprocessed/'
@@ -59,14 +60,14 @@ def _get_path_cmip(base_folder=cmip5_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    return '/'.join([base_folder, center, model, exp, period, comp, varname, run_id]) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
+    return '/'.join([base_folder, center, model, exp, period, comp, varname, run_id, 'v????????']) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg
 def load_cmip(base_folder=cmip5_folder,
               model='MPI-ESM-LR',
               center='MPI-M',
-              exp='historial',
+              exp='historical',
               period='mon',
               varname='tos',
               comp='ocean',
@@ -102,6 +103,16 @@ def load_cmip(base_folder=cmip5_folder,
     else:
         print('xr.open_mfdataset('+ncfiles_cmip+')['+varname+']')
         return xr.open_mfdataset(ncfiles_cmip)[varname]
+
+
+def load_cmip_from_center_model_list(center_list=['MPI-M', 'NCAR'], model_list=['MPI-ESM-LR', 'CCSM4'], **cmip_kwargs):
+    data = []
+    for center, model in zip(center_list, model_list):
+        print('Load', center, model)
+        data.append(load_cmip(center=center, model=model, **cmip_kwargs))
+    data = xr.concat(data, 'center')
+    data['center'] = center_list
+    return center
 
 
 def read_table_file(table_file_str):

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -126,6 +126,15 @@ def load_cmip_from_center_model_list(center_list=['MPI-M', 'NCAR'], model_list=[
     return data
 
 
+def load_cmip_many_varnames(varnamelist, **cmip_kwargs):
+    data = []
+    for varname in varnamelist:
+        print('Load', varname)
+        data.append(load_cmip(varname=varname, **cmip_kwargs))
+    data = xr.merge(data)
+    return data
+
+
 def read_table_file(table_file_str):
     """Read partab/.codes file."""
     table_file = pd.read_fwf(

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -60,7 +60,7 @@ def _get_path_cmip(base_folder=cmip5_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    return '/'.join([base_folder, center, model, exp, period, comp, comp[0].upper()+period, run_id, 'v????????', varname]) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
+    return '/'.join([base_folder, center, model, exp, period, comp, comp[0].upper()+period, run_id, sorted(glob.glob('v????????'))[-1], varname]) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg
@@ -102,7 +102,7 @@ def load_cmip(base_folder=cmip5_folder,
                 options='-r')).squeeze()[varname]
     else:
         print('xr.open_mfdataset('+ncfiles_cmip+')['+varname+']')
-        return xr.open_mfdataset(ncfiles_cmip)[varname]
+        return xr.open_mfdataset(ncfiles_cmip, concat_dim='time')[varname]
 
 
 def load_cmip_from_center_model_list(center_list=['MPI-M', 'NCAR'], model_list=['MPI-ESM-LR', 'CCSM4'], **cmip_kwargs):
@@ -112,7 +112,7 @@ def load_cmip_from_center_model_list(center_list=['MPI-M', 'NCAR'], model_list=[
         data.append(load_cmip(center=center, model=model, **cmip_kwargs))
     data = xr.concat(data, 'center')
     data['center'] = center_list
-    return center
+    return data
 
 
 def read_table_file(table_file_str):

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -108,7 +108,7 @@ def load_cmip(base_folder=cmip5_folder,
         return xr.open_dataset(
             cdo.addc(
                 '0',
-                input=operator + ' -select,name=' + varname +
+                input=operator + ' -select,name=' + varname + ' ' +
                 ncfiles_cmip,
                 options='-r')).squeeze()[varname]
     else:
@@ -126,7 +126,7 @@ def load_cmip_from_center_model_list(center_list=['MPI-M', 'NCAR'], model_list=[
     return data
 
 
-def load_cmip_many_varnames(varnamelist, **cmip_kwargs):
+def load_cmip_many_varnames(varnamelist=['tos', 'sos'], **cmip_kwargs):
     data = []
     for varname in varnamelist:
         print('Load', varname)

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -60,7 +60,7 @@ def _get_path_cmip(base_folder=cmip5_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    return '/'.join([base_folder, center, model, exp, period, comp, varname, run_id, 'v????????']) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
+    return '/'.join([base_folder, center, model, exp, period, comp, comp[0].upper()+period, run_id, 'v????????', varname]) + '/' + '_'.join([varname, comp[0].upper()+period, model, exp, run_id, timestr]) + ending
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -41,9 +41,8 @@ sample_file_dir = file_origin + 'experiments/sample_files/'
 
 PM_path = file_origin + 'experiments/'
 GE_path = file_origin + 'experiments/GE/'
-center = 'MPI-M'
-model = 'MPI-ESM-LR'
-cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output/' + center + '/' + model
+
+cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output/'
 my_GE_path = file_origin + '160701_Grand_Ensemble/'
 GE_post = my_GE_path + 'postprocessed/'
 PM_post = PM_path + 'postprocessed/'

--- a/pymistral/setup.py
+++ b/pymistral/setup.py
@@ -43,13 +43,15 @@ PM_path = file_origin + 'experiments/'
 GE_path = file_origin + 'experiments/GE/'
 center = 'MPI-M'
 model = 'MPI-ESM-LR'
-cmip_folder = '/work/ik0555/cmip5/archive/CMIP5/output/' + center + '/' + model
+cmip5_folder = '/work/ik0555/cmip5/archive/CMIP5/output/' + center + '/' + model
 my_GE_path = file_origin + '160701_Grand_Ensemble/'
 GE_post = my_GE_path + 'postprocessed/'
 PM_post = PM_path + 'postprocessed/'
 
 
-def _get_path_cmip(base_folder=cmip_folder,
+def _get_path_cmip(base_folder=cmip5_folder,
+                   model='MPI-ESM-LR',
+                   center='MPI-M',
                    exp='esmControl',
                    period='mon',
                    varname='co2',
@@ -57,9 +59,7 @@ def _get_path_cmip(base_folder=cmip_folder,
                    run_id='r1i1p1',
                    ending='.nc',
                    timestr='*'):
-    return base_folder + '/' + exp + '/' + period + '/' + comp + '/' + varname + '/' + run_id + '/' + varname + '_' + comp[
-        0].upper(
-    ) + period + '_' + model + '_' + exp + '_' + run_id + '_' + timestr + ending
+    return '/'.join([base_folder, center, model, exp, period, comp, varname, run_id]) + '/' + '_'.join([varname, comp[0].upper(), period, model, exp, run_id, timestr]) + ending
 
 
 # TODO: adapt for CMIP6, maybe with CMIP=5 arg


### PR DESCRIPTION
basic functionality
```python
import pymistral
ds = pymistral.setup.load_cmip()
ds = pymistral.setup.load_cmip(operator='-fldmean')
ds = pymistral.setup.load_cmip_from_center_model_list()
ds = pymistral.setup.load_cmip_many_varnames()

```
should do:
- [x] load many variables from one model
- [x] load a variable from all models


To Do:
- [x] add checks for Amon, ... based on varnames
- [x] loop over list of models
- [x] implement list of models, centers, ...

Future add-ons:
- [ ] CMIP6